### PR TITLE
Ab upgrade 0725

### DIFF
--- a/address_bleach.py
+++ b/address_bleach.py
@@ -3,7 +3,8 @@ from csv import DictReader
 import textwrap
 
 
-def compare(address1, address2, ste_compare='ignore_missing', body_score_threshold=65.0):
+def compare(address1, address2, ste_compare='ignore_missing', body_score_threshold=65.0,
+            ignore_directional_match=False):
     """ Compares the elements of two address_bleach.Address Objects.
         --Arguments--
         address1: Expects address_bleach.Address
@@ -17,6 +18,8 @@ def compare(address1, address2, ste_compare='ignore_missing', body_score_thresho
                                     or address2 details.
         body_score_threshold: Expects float.  Default 65% Body Score Match. User can determine a
                               higher match rate, if desired.
+        ignore_directional_match: Expects bool.  Default False. Determines whether directionals
+        should be ignored in match comparison rules.
         Returns dict:
         Match_Status: Match / No Match / Potential (str)
                       NOTE: 'No Match' will provide no score or additional match criteria.
@@ -99,36 +102,32 @@ def compare(address1, address2, ste_compare='ignore_missing', body_score_thresho
                                == address2.address_details['street_block'])
             grid_match = bool(address1.address_details['grid'] == address2.address_details['grid'])
             directional_match = \
-                bool(address1.address_details['street_directional']
-                     == address2.address_details['street_directional'])
+                all([address1.address_details['street_directional']
+                     == address2.address_details['street_directional'],
+                     address1.address_details['directional_type']
+                     == address2.address_details['directional_type']])
+            directional_match_rule = directional_match if not ignore_directional_match else True
             zip3_plus_streetnum_chks = all([zip3_match, street_num_match, block_match, grid_match])
             addr1_body_score = addr_body_compare(address1.address_details['street_body'],
                                                  address2.address_details['street_body'])
             addr2_body_score = addr_body_compare(address2.address_details['street_body'],
                                                  address1.address_details['street_body'])
-            # Completely different Street Bodies
+            # Match based on Street Numbers, Zip/City, Suite Compare, Directional, & Body Score
             if all([zip3_plus_streetnum_chks,
-                    any([addr1_body_score == 0,
-                         addr2_body_score == 0])]):
-                comparison_decision = \
-                    {'Match_Status': 'No Match', 'Address1_Body_Score': addr1_body_score,
-                     'Address2_Body_Score': addr2_body_score, 'Zip5_Match': zip5_match,
-                     'City_Match': city_match, 'Directional_Match': directional_match,
-                     'Ste_Match': ste_match}
-            # Match based on Street Numbers, Zip/City, Suite Compare, & Body Score
-            elif all([zip3_plus_streetnum_chks,
-                      ste_chk,
-                      addr1_body_score >= body_score_threshold,
-                      addr2_body_score >= body_score_threshold,
-                      any([zip5_match, city_match])]):
+                    ste_chk,
+                    directional_match_rule,
+                    addr1_body_score >= body_score_threshold,
+                    addr2_body_score >= body_score_threshold,
+                    any([zip5_match, city_match])]):
                 comparison_decision = \
                     {'Match_Status': 'Match', 'Address1_Body_Score': addr1_body_score,
                      'Address2_Body_Score': addr2_body_score,
                      'Zip5_Match': zip5_match, 'City_Match': city_match,
                      'Directional_Match': directional_match, 'Ste_Match': ste_match}
-            # Potential based on Street Numbers, Zip/City, Suite Compare, & Body Score
+            # Potential based on Street Numbers, Zip/City, Suite Compare, Directional, & Body Score
             elif all([zip3_plus_streetnum_chks,
                       ste_chk,
+                      directional_match_rule,
                       addr1_body_score > 0,
                       addr2_body_score > 0,
                       any([zip5_match, city_match])]):
@@ -164,7 +163,8 @@ class Address:
         self.pobox_sts = False
         self.address_details = \
             {'grid': '', 'street_block': '', 'street_num': '', 'street_body': '',
-             'street_suffix': '', 'street_directional': '', 'suite_num': '', 'box_num': ''}
+             'street_suffix': '', 'street_directional': '', 'directional_type': '', 'suite_num': '',
+             'box_num': ''}
         # Files/Exceptions
         self.files = {'ste_identifiers': str(Path(__file__).parent.absolute())
                       + '\\address_bleach\\ste_identifiers.csv',
@@ -191,6 +191,7 @@ class Address:
                       Street Body: {self.address_details['street_body']}
                       Street Suffix: {self.address_details['street_suffix']}
                       Street Directional: {self.address_details['street_directional']}
+                      Directional Type: {self.address_details['directional_type']}
                       Street Suite Number: {self.address_details['suite_num']}
                       PO Box Number: {self.address_details['box_num']}'''
         return textwrap.dedent(details)
@@ -226,6 +227,7 @@ class Address:
         [StreetNumSuffixOrDirectional]
         [StreetBody]
         [StreetBodyDirectional]
+        [DirectionalType]
         [SteBldg Extension]
         Returns dict()."""
 
@@ -394,20 +396,24 @@ class Address:
             potential_keys = [k for k in potentials.keys()]
             directional_key = None
             directional_val = ''
+            f_directional_type = ''
             if len(potential_keys) == 2:
                 if abs(potential_keys[1] - potential_keys[0]) > 1:
                     # Position of each directional is greater than one element away from each other.
                     # 123 N Carolina St SE - Grabs SE
                     directional_key = max(potential_keys)
                     directional_val = potentials[max(potential_keys)]
+                    f_directional_type = 'post'
                 else:
                     # Position of each directional is next to each other.
                     # 789 N West Side Rd - Grabs N
                     directional_key = min(potential_keys)
                     directional_val = potentials[min(potential_keys)]
+                    f_directional_type = 'pre'
             elif len(potentials) == 1:
                 directional_key = min(potential_keys)
                 directional_val = potentials[min(potential_keys)]
+                f_directional_type = 'pre' if min(potential_keys) < 2 else 'post'
             else:
                 # More than 2 directionals observed...document it and figure out why it exists
                 # In case it's not evident, this shouldn't occur
@@ -417,7 +423,7 @@ class Address:
                              'Exception': 'More than 2 potential Directionals exist in address.'})
             if directional_val.upper() in conversion.keys():
                 directional_val = conversion[directional_val.upper()]
-            return directional_val, directional_key, exceptions
+            return directional_val, directional_key, f_directional_type, exceptions
 
         # Begin Address Breakdown #
         removals = set()
@@ -469,7 +475,7 @@ class Address:
         removals, bd_dict = remove_found_types(removals, bd_dict)
 
         # Identification of Directional
-        street_directional, match_key, bd_exceptions = find_directional(bd_dict)
+        street_directional, match_key, directional_type, bd_exceptions = find_directional(bd_dict)
         if match_key:
             removals.add(match_key)
             remove_found_types(removals, bd_dict)
@@ -479,7 +485,8 @@ class Address:
 
         addr_deets = {'grid': grid_id, 'street_block': street_block, 'street_num': street_number,
                       'street_body': street_body, 'street_suffix': street_suffix,
-                      'street_directional': street_directional, 'suite_num': addr_ste_num,
+                      'street_directional': street_directional,
+                      'directional_type': directional_type, 'suite_num': addr_ste_num,
                       'box_num': box_num}
 
         return addr_deets, bd_exceptions

--- a/address_bleach.py
+++ b/address_bleach.py
@@ -3,8 +3,20 @@ from csv import DictReader
 import textwrap
 
 
-def compare(address1, address2):
+def compare(address1, address2, ste_compare='ignore_missing', body_score_threshold=65.0):
     """ Compares the elements of two address_bleach.Address Objects.
+        --Arguments--
+        address1: Expects address_bleach.Address
+        address2: Expects address_bleach.Address
+        ste_compare: {'ignore_missing', 'ignore_all', 'ignore_none'}, default 'ignore_missing'
+                     - ignore_missing: Compares Suite numbers when both are populated, but ignores
+                                       comparison when either address1 or address2 do not have a
+                                       suite number.
+                     - ignore_all: Ignores suite number population in address comparison.
+                     - ignore_none: Compares Suite Numbers regardless of its population in address1
+                                    or address2 details.
+        body_score_threshold: Expects float.  Default 65% Body Score Match. User can determine a
+                              higher match rate, if desired.
         Returns dict:
         Match_Status: Match / No Match / Potential (str)
                       NOTE: 'No Match' will provide no score or additional match criteria.
@@ -16,7 +28,6 @@ def compare(address1, address2):
         Ste_Match: ste_match (bool)
         [Match_Status, Address1_Body_Score, Address2_Body_Score, Zip5_Match, City_Match,
          Directional_Match, Ste_Match]
-         TODO: Add functionality to ignore suite number in comparison findings if desired.
     """
 
     def addr_body_compare(addr_breakdown_1, addr_breakdown_2):
@@ -38,10 +49,28 @@ def compare(address1, address2):
     comparison_decision = {'Match_Status': 'No Match', 'Address1_Body_Score': 0,
                            'Address2_Body_Score': 0, 'Zip5_Match': False, 'City_Match': False,
                            'Directional_Match': False, 'Ste_Match': False}
+    # Component Evaluation
     zip3_match = bool(address1.zipcode[:3] == address2.zipcode[:3])
     zip5_match = bool(address1.zipcode[:5] == address2.zipcode[:5])
     city_match = bool(address1.city.upper() == address2.city.upper())
-    # Compare: Check if PO Box, if not, check if Street elements match.
+    # Suite Comparison
+    if ste_compare == 'ignore_all':
+        ste_match = True
+        ste_chk = True
+    elif ste_compare == 'ignore_none':
+        ste_match = bool(address1.address_details['suite_num']
+                         == address2.address_details['suite_num'])
+        ste_chk = ste_match
+    elif ste_compare == 'ignore_missing':
+        ste_match = bool(address1.address_details['suite_num']
+                         == address2.address_details['suite_num'])
+        missing_ste = all([not ste_match,
+                           any([not address1.address_details['suite_num'],
+                                not address2.address_details['suite_num']])])
+        ste_chk = any([missing_ste, ste_match])
+    else:
+        raise ValueError("address_bleach: Invalid ste_compare value.")
+    # Compare PO Boxes
     if address1.pobox_sts and address2.pobox_sts:
         if (address1.address_details['box_num'] == address2.address_details['box_num']
                 and address1.state.upper() == address2.state.upper()):
@@ -54,6 +83,7 @@ def compare(address1, address2):
         comparison_decision = {'Match_Status': 'No Match', 'Address1_Body_Score': 0,
                                'Address2_Body_Score': 0, 'Zip5_Match': False, 'City_Match': False,
                                'Directional_Match': False, 'Ste_Match': False}
+    # Compare Street Addresses
     elif not address1.pobox_sts and not address2.pobox_sts:
         state_match = bool(address1.state.upper() == address2.state.upper())
         if not state_match:
@@ -62,6 +92,7 @@ def compare(address1, address2):
                                    'City_Match': False, 'Directional_Match': False,
                                    'Ste_Match': False}
         else:
+            # Street Element Evaluation
             street_num_match = bool(address1.address_details['street_num']
                                     == address2.address_details['street_num'])
             block_match = bool(address1.address_details['street_block']
@@ -70,50 +101,59 @@ def compare(address1, address2):
             directional_match = \
                 bool(address1.address_details['street_directional']
                      == address2.address_details['street_directional'])
-            ste_match = bool(address1.address_details['suite_num']
-                             == address2.address_details['suite_num'])
-            missing_ste = all([not ste_match,
-                               any([not address1.address_details['suite_num'],
-                                    not address2.address_details['suite_num']])])
             zip3_plus_streetnum_chks = all([zip3_match, street_num_match, block_match, grid_match])
-            ste_chk = any([not ste_match and missing_ste, ste_match])
-            if zip3_plus_streetnum_chks and ste_chk:
-                # Confirmed 3-digit Zip, street numbers, and block/grid match
-                # Suite numbers either match or one is populated and the other is not.
-                addr1_body_score = \
-                    addr_body_compare(address1.address_details['street_body'],
-                                      address2.address_details['street_body'])
-                addr2_body_score = \
-                    addr_body_compare(address2.address_details['street_body'],
-                                      address1.address_details['street_body'])
-
-                if addr1_body_score == 0 or addr2_body_score == 0:
-                    # Completely different Street Bodies
-                    comparison_decision = \
-                        {'Match_Status': 'No Match', 'Address1_Body_Score': addr1_body_score,
-                         'Address2_Body_Score': addr2_body_score, 'Zip5_Match': zip5_match,
-                         'City_Match': city_match, 'Directional_Match': directional_match,
-                         'Ste_Match': ste_match}
-                elif ((zip5_match or city_match)
-                      or (addr1_body_score == 100.0 and addr2_body_score == 100.0)):
-                    comparison_decision = \
-                        {'Match_Status': 'Match', 'Address1_Body_Score': addr1_body_score,
-                            'Address2_Body_Score': addr2_body_score,
-                            'Zip5_Match': zip5_match, 'City_Match': city_match,
-                            'Directional_Match': directional_match, 'Ste_Match': ste_match}
-                else:
-                    comparison_decision = \
-                        {'Match_Status': 'Potential', 'Address1_Body_Score': addr1_body_score,
-                         'Address2_Body_Score': addr2_body_score, 'Zip5_Match': zip5_match,
-                         'City_Match': city_match, 'Directional_Match': directional_match,
-                         'Ste_Match': ste_match}
+            addr1_body_score = addr_body_compare(address1.address_details['street_body'],
+                                                 address2.address_details['street_body'])
+            addr2_body_score = addr_body_compare(address2.address_details['street_body'],
+                                                 address1.address_details['street_body'])
+            # Completely different Street Bodies
+            if all([zip3_plus_streetnum_chks,
+                    any([addr1_body_score == 0,
+                         addr2_body_score == 0])]):
+                comparison_decision = \
+                    {'Match_Status': 'No Match', 'Address1_Body_Score': addr1_body_score,
+                     'Address2_Body_Score': addr2_body_score, 'Zip5_Match': zip5_match,
+                     'City_Match': city_match, 'Directional_Match': directional_match,
+                     'Ste_Match': ste_match}
+            # Match based on Street Numbers, Zip/City, Suite Compare, & Body Score
+            elif all([zip3_plus_streetnum_chks,
+                      ste_chk,
+                      addr1_body_score >= body_score_threshold,
+                      addr2_body_score >= body_score_threshold,
+                      any([zip5_match, city_match])]):
+                comparison_decision = \
+                    {'Match_Status': 'Match', 'Address1_Body_Score': addr1_body_score,
+                     'Address2_Body_Score': addr2_body_score,
+                     'Zip5_Match': zip5_match, 'City_Match': city_match,
+                     'Directional_Match': directional_match, 'Ste_Match': ste_match}
+            # Potential based on Street Numbers, Zip/City, Suite Compare, & Body Score
+            elif all([zip3_plus_streetnum_chks,
+                      ste_chk,
+                      addr1_body_score > 0,
+                      addr2_body_score > 0,
+                      any([zip5_match, city_match])]):
+                comparison_decision = \
+                    {'Match_Status': 'Potential', 'Address1_Body_Score': addr1_body_score,
+                     'Address2_Body_Score': addr2_body_score, 'Zip5_Match': zip5_match,
+                     'City_Match': city_match, 'Directional_Match': directional_match,
+                     'Ste_Match': ste_match}
+            else:
+                comparison_decision = \
+                    {'Match_Status': 'No Match', 'Address1_Body_Score': addr1_body_score,
+                     'Address2_Body_Score': addr2_body_score, 'Zip5_Match': zip5_match,
+                     'City_Match': city_match, 'Directional_Match': directional_match,
+                     'Ste_Match': ste_match}
     return comparison_decision
 
 
 class Address:
     """ Address Object for address_bleach, which is intended to make
         the cleanup and comparison of address data much easier by
-        breaking the data down into more manageable components."""
+        breaking the data down into more manageable components.
+        TODO: Handle Pre- or Post-Directionals to manage cities that have different addresses
+        depending on their position:
+        Example: 123 S Main St and 123 Main St S are in two different areas of the city in Houston
+    """
 
     def __init__(self, address, city, state, zipcode, wdir=str(Path.cwd())):
 

--- a/address_bleach_notebook.ipynb
+++ b/address_bleach_notebook.ipynb
@@ -29,6 +29,7 @@
       "Street Body: Main\n",
       "Street Suffix: ST\n",
       "Street Directional: S\n",
+      "Directional Type: post\n",
       "Street Suite Number: \n",
       "PO Box Number: \n"
      ]
@@ -59,6 +60,7 @@
       "Street Body: Main\n",
       "Street Suffix: ST\n",
       "Street Directional: S\n",
+      "Directional Type: post\n",
       "Street Suite Number: B\n",
       "PO Box Number: \n"
      ]
@@ -89,6 +91,7 @@
       "Street Body: Main\n",
       "Street Suffix: ST\n",
       "Street Directional: S\n",
+      "Directional Type: post\n",
       "Street Suite Number: B\n",
       "PO Box Number: \n"
      ]
@@ -119,6 +122,7 @@
       "Street Body: Main\n",
       "Street Suffix: ST\n",
       "Street Directional: S\n",
+      "Directional Type: post\n",
       "Street Suite Number: \n",
       "PO Box Number: \n"
      ]
@@ -149,6 +153,7 @@
       "Street Body: \n",
       "Street Suffix: RD\n",
       "Street Directional: S\n",
+      "Directional Type: post\n",
       "Street Suite Number: \n",
       "PO Box Number: \n"
      ]
@@ -179,6 +184,7 @@
       "Street Body: BLUEMOUND\n",
       "Street Suffix: RD\n",
       "Street Directional: \n",
+      "Directional Type: \n",
       "Street Suite Number: \n",
       "PO Box Number: \n"
      ]
@@ -209,6 +215,7 @@
       "Street Body: N Carolina\n",
       "Street Suffix: ST\n",
       "Street Directional: W\n",
+      "Directional Type: post\n",
       "Street Suite Number: \n",
       "PO Box Number: \n"
      ]
@@ -239,6 +246,7 @@
       "Street Body: Gradine\n",
       "Street Suffix: DR\n",
       "Street Directional: E\n",
+      "Directional Type: pre\n",
       "Street Suite Number: J15\n",
       "PO Box Number: \n"
      ]
@@ -280,7 +288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -295,7 +303,7 @@
        " 'Ste_Match': False}"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -308,19 +316,215 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "{'Match_Status': 'No Match',\n",
-       " 'Address1_Body_Score': 0,\n",
-       " 'Address2_Body_Score': 0,\n",
-       " 'Zip5_Match': False,\n",
-       " 'City_Match': False,\n",
-       " 'Directional_Match': False,\n",
+       " 'Address1_Body_Score': 100.0,\n",
+       " 'Address2_Body_Score': 100.0,\n",
+       " 'Zip5_Match': True,\n",
+       " 'City_Match': True,\n",
+       " 'Directional_Match': True,\n",
        " 'Ste_Match': False}"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "c_addr1 = ab.Address('4568 East Gradine Drive SUITE J15', 'Seattle', 'WA', '98039')\n",
+    "c_addr2 = ab.Address('4568 E Gradine Dr', 'Seattle', 'WA', '98039')\n",
+    "ab.compare(c_addr1, c_addr2, ste_compare='ignore_none')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Match_Status': 'No Match',\n",
+       " 'Address1_Body_Score': 100.0,\n",
+       " 'Address2_Body_Score': 100.0,\n",
+       " 'Zip5_Match': True,\n",
+       " 'City_Match': True,\n",
+       " 'Directional_Match': True,\n",
+       " 'Ste_Match': False}"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "c_addr1 = ab.Address('4568 East Gradine Drive SUITE J15', 'Seattle', 'WA', '98039')\n",
+    "c_addr2 = ab.Address('4568 E Gradine Dr STE E5', 'Seattle', 'WA', '98039')\n",
+    "ab.compare(c_addr1, c_addr2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Match_Status': 'Match',\n",
+       " 'Address1_Body_Score': 100.0,\n",
+       " 'Address2_Body_Score': 100.0,\n",
+       " 'Zip5_Match': True,\n",
+       " 'City_Match': True,\n",
+       " 'Directional_Match': True,\n",
+       " 'Ste_Match': True}"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "c_addr1 = ab.Address('4568 East Gradine Drive SUITE J15', 'Seattle', 'WA', '98039')\n",
+    "c_addr2 = ab.Address('4568 E Gradine Dr STE E5', 'Seattle', 'WA', '98039')\n",
+    "ab.compare(c_addr1, c_addr2, ste_compare='ignore_all')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Match_Status': 'No Match',\n",
+       " 'Address1_Body_Score': 100.0,\n",
+       " 'Address2_Body_Score': 100.0,\n",
+       " 'Zip5_Match': True,\n",
+       " 'City_Match': True,\n",
+       " 'Directional_Match': False,\n",
+       " 'Ste_Match': True}"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "c_addr1 = ab.Address('123 S Main Street', 'Seattle', 'WA', '98039')\n",
+    "c_addr2 = ab.Address('123 Main St S', 'Seattle', 'WA', '98039')\n",
+    "ab.compare(c_addr1, c_addr2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Match_Status': 'Match',\n",
+       " 'Address1_Body_Score': 100.0,\n",
+       " 'Address2_Body_Score': 100.0,\n",
+       " 'Zip5_Match': True,\n",
+       " 'City_Match': True,\n",
+       " 'Directional_Match': False,\n",
+       " 'Ste_Match': True}"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "c_addr1 = ab.Address('123 S Main Street', 'Seattle', 'WA', '98039')\n",
+    "c_addr2 = ab.Address('123 Main St S', 'Seattle', 'WA', '98039')\n",
+    "ab.compare(c_addr1, c_addr2, ignore_directional_match=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Match_Status': 'Match',\n",
+       " 'Address1_Body_Score': 67.0,\n",
+       " 'Address2_Body_Score': 67.0,\n",
+       " 'Zip5_Match': True,\n",
+       " 'City_Match': True,\n",
+       " 'Directional_Match': True,\n",
+       " 'Ste_Match': True}"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "c_addr1 = ab.Address('5836 MARTIN G ANON BLVD', 'Seattle', 'WA', '98039')\n",
+    "c_addr2 = ab.Address('5836 M G ANON BLVD', 'Seattle', 'WA', '98039')\n",
+    "ab.compare(c_addr1, c_addr2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Match_Status': 'Potential',\n",
+       " 'Address1_Body_Score': 67.0,\n",
+       " 'Address2_Body_Score': 67.0,\n",
+       " 'Zip5_Match': True,\n",
+       " 'City_Match': True,\n",
+       " 'Directional_Match': True,\n",
+       " 'Ste_Match': True}"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "c_addr1 = ab.Address('5836 MARTIN G ANON BLVD', 'Seattle', 'WA', '98039')\n",
+    "c_addr2 = ab.Address('5836 M G ANON BLVD', 'Seattle', 'WA', '98039')\n",
+    "ab.compare(c_addr1, c_addr2, body_score_threshold=80.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'Match_Status': 'Potential',\n",
+       " 'Address1_Body_Score': 33.0,\n",
+       " 'Address2_Body_Score': 50.0,\n",
+       " 'Zip5_Match': True,\n",
+       " 'City_Match': True,\n",
+       " 'Directional_Match': True,\n",
+       " 'Ste_Match': True}"
       ]
      },
      "execution_count": 18,
@@ -329,8 +533,8 @@
     }
    ],
    "source": [
-    "c_addr1 = ab.Address('4568 East Gradine Drive SUITE J15', 'Seattle', 'WA', '98039')\n",
-    "c_addr2 = ab.Address('4568 E Gradine Dr STE E5', 'Seattle', 'WA', '98039')\n",
+    "c_addr1 = ab.Address('5836 MARTIN G ANON BLVD', 'Seattle', 'WA', '98039')\n",
+    "c_addr2 = ab.Address('5836 ANON HOWITZ BLVD', 'Seattle', 'WA', '98039')\n",
     "ab.compare(c_addr1, c_addr2)"
    ]
   },


### PR DESCRIPTION
Function `address_bleach.compare` has been overhauled to more accurately identify matches and potentials as well as some additional options to provide the user decisions in how matching is achieved:

- `ste_compare` argument provides user options over how Suite Numbers are taken into account for comparison decision-making.
- `body_score_threshold` lets the user determine what percentage of elements are required to consider a body-score match.
- `ignore_directional_match` lets the user ignore directionals when making comparison.

Additionally, the `address_bleach.Address` has received an update within it's `breakdown_details` method.  It now has an additional key within `address_details` called _directional_type_, which will store either 'pre' or 'post' within it's value.  This value is used for directional comparison unless otherwise ignored.